### PR TITLE
Fix: Initial corrections for Q&A generation and build error

### DIFF
--- a/src/hooks/useDatasetGeneration.ts
+++ b/src/hooks/useDatasetGeneration.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { FileData, UrlData, ProcessedData, FineTuningGoal, QAPair, KnowledgeGap, SyntheticQAPair } from '../types';
 import { geminiService } from '../services/geminiService';
-import { SYNTHETIC_QA_TARGET } from '../constants';
+import { SYNTHETIC_QA_TARGET_MIN, SYNTHETIC_QA_TARGET_MAX } from '../constants';
 
 // Create promises for conditional imports without top-level await
 const openRouterServicePromise = import('../services/openRouterService').then(module => {


### PR DESCRIPTION
This commit includes the following changes:

1.  **Resolved Build Error:**
    - I fixed the Netlify build error `"SYNTHETIC_QA_TARGET" is not exported by "src/constants/index.ts"`.
    - I updated `src/services/openRouterService.ts` to correctly use `SYNTHETIC_QA_TARGET_MIN` from constants, as was intended by the surrounding logic for default values.

2.  **Corrected Imports in `useDatasetGeneration.ts`:**
    - I fixed a runtime error in `src/hooks/useDatasetGeneration.ts` where `SYNTHETIC_QA_TARGET_MIN` and `SYNTHETIC_QA_TARGET_MAX` were being used without being imported.
    - These constants are used to determine the number of synthetic Q&A pairs to generate.

**Further Work Required:**

Based on your recent feedback, significant adjustments are still needed:

*   **Gemini Q&A Generation (Initial Pairs):**
    - Currently, `geminiService.ts` generates *exactly* `QA_PAIR_COUNT_TARGET` (100) pairs. This needs to be modified to ensure 100 is a *minimum* target, without a strict upper limit for this stage.

*   **Nemotron/OpenRouter Q&A Generation (Synthetic Pairs):**
    - The logic in `useDatasetGeneration.ts` currently aims to generate `SYNTHETIC_QA_TARGET_MAX` (80) pairs *per identified knowledge gap*.
    - This needs to be changed to target a *total minimum of 50 synthetic pairs*, distributed approximately evenly across all dynamically identified gaps.

I will address these pending changes next.